### PR TITLE
Reflect the subnet merge

### DIFF
--- a/puppet/modules/centos_cloud/manifests/controller/neutron.pp
+++ b/puppet/modules/centos_cloud/manifests/controller/neutron.pp
@@ -91,10 +91,10 @@ class centos_cloud::controller::neutron (
 
   # Provider subnet
   neutron_subnet { 'publicsubnet':
-    cidr             => '172.19.4.0/22',
-    gateway_ip       => '172.19.7.254',
+    cidr             => '172.19.4.0/21',
+    gateway_ip       => '172.19.3.254',
     network_name     => 'publicnet',
-    dns_nameservers  => ['172.19.7.253'],
+    dns_nameservers  => ['172.19.0.12'],
     allocation_pools => ["start=172.19.4.10,end=172.19.7.250"],
   }
 }


### PR DESCRIPTION
# Subnet merge

The two subnets 172.19.0.0/22 (rdu2) and 172.19.4.0/22 (rdu2c) have merged as all hardware equipments are now moved/relocated to rdu2c. So all local and no need to use the temporary vpn tunnel anymore
