### PR TITLE
Update centos-cloud to Newton

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ Controller::
 
     ssh root@controller
     yum -y install git
-    git clone https://github.com/dmsimard/centos-cloud
+    git clone https://github.com/CentOS/centos-cloud
     cd centos-cloud
     ./bootstrap-controller.sh
 
@@ -16,7 +16,7 @@ Compute Node(s)::
 
     ssh root@compute01
     yum -y install git
-    git clone https://github.com/dmsimard/centos-cloud
+    git clone https://github.com/CentOS/centos-cloud
     cd centos-cloud
     ./bootstrap-compute.sh <ipaddress_of_controller>
 

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Compute Node(s)::
     yum -y install git
     git clone https://github.com/CentOS/centos-cloud
     cd centos-cloud
-    ./bootstrap-compute.sh <ipaddress_of_controller>
+    ./bootstrap-compute.sh
 
 To generate test resources (ssh key, image, instance)::
 

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -1,0 +1,1 @@
+source_location: "/root/centos-cloud"

--- a/ansible/playbooks/pull-config.yml
+++ b/ansible/playbooks/pull-config.yml
@@ -5,6 +5,6 @@
   tasks:
     - git:
         repo: "https://github.com/dmsimard/centos-cloud"
-        dest: "/root/centos-cloud"
+        dest: "{{ source_location }}"
         update: "yes"
         force: "yes"

--- a/ansible/playbooks/pull-config.yml
+++ b/ansible/playbooks/pull-config.yml
@@ -4,7 +4,7 @@
   gather_facts: no
   tasks:
     - git:
-        repo: "https://github.com/dmsimard/centos-cloud"
+        repo: "https://github.com/CentOS/centos-cloud"
         dest: "{{ source_location }}"
         update: "yes"
         force: "yes"

--- a/ansible/playbooks/update-config.yml
+++ b/ansible/playbooks/update-config.yml
@@ -4,10 +4,8 @@
   gather_facts: yes
   tasks:
     - shell: |
-        pushd /etc/puppet
-        PUPPETFILE=/root/centos-cloud/puppet/Puppetfile r10k puppetfile install -v
-        cp -a /root/centos-cloud/puppet/modules/centos_cloud modules/
-        popd
+        r10k puppetfile install --puppetfile {{ source_location }}/puppet/Puppetfile --moduledir /etc/puppet/modules -v
+        cp -a {{ source_location }}/puppet/modules/centos_cloud /etc/puppet/modules/
 
 - name: Update controller
   hosts: controller

--- a/baseline.sh
+++ b/baseline.sh
@@ -17,7 +17,7 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
-yum -y install yum-plugin-priorities rubygems centos-release-openstack-mitaka
+yum -y install yum-plugin-priorities rubygems centos-release-openstack-newton
 yum -y install puppet python-openstackclient
 gem install r10k
 

--- a/baseline.sh
+++ b/baseline.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # This script will do the basic common stuff needed everywhere
-
 if rpm -q NetworkManager; then
     service NetworkManager stop
     yum -y remove Network\*
@@ -21,7 +20,6 @@ yum -y install yum-plugin-priorities rubygems centos-release-openstack-newton
 yum -y install puppet python-openstackclient
 gem install r10k
 
-pushd /etc/puppet
-PUPPETFILE=/root/centos-cloud/puppet/Puppetfile r10k puppetfile install -v
-cp -a /root/centos-cloud/puppet/modules/centos_cloud modules/
-popd
+cwd=$(cd `dirname $0` && pwd -P)
+r10k puppetfile install --puppetfile ${cwd}/puppet/Puppetfile --moduledir /etc/puppet/modules -v
+cp -a ${cwd}/puppet/modules/centos_cloud /etc/puppet/modules/

--- a/bootstrap-compute.sh
+++ b/bootstrap-compute.sh
@@ -7,7 +7,6 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
-echo "${1} controller.openstack.ci.centos.org" >> /etc/hosts
 puppet apply -e "include ::centos_cloud::compute" || exit 1
 
 # Sanity check

--- a/bootstrap-controller.sh
+++ b/bootstrap-controller.sh
@@ -7,7 +7,6 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
-echo "127.0.0.1 controller.openstack.ci.centos.org" >>/etc/hosts
 puppet apply -e "include ::centos_cloud::controller" || exit 1
 
 # Sanity check

--- a/bootstrap-resources.sh
+++ b/bootstrap-resources.sh
@@ -4,13 +4,8 @@ pushd /root
 source openrc
 ssh-keygen -f .ssh/id_rsa -t rsa -N ''
 openstack keypair create --public-key .ssh/id_rsa.pub centos-cloud-key
-wget -q http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2 -O /tmp/centos7.qcow2
-virt-sysprep --enable=ssh-hostkeys,udev-persistent-net,net-hwaddr,dhcp-client-state,dhcp-server-state,customize \
-             --write '/etc/cloud/cloud.cfg.d/00_disable_ec2_metadata.cfg:disable_ec2_metadata: True' \
-             --write '/etc/cloud/cloud.cfg.d/99_manage_etc_hosts.cfg:manage_etc_hosts: True' \
-             --root-password password:root \
-             -a /tmp/centos7.qcow2
-openstack image create --disk-format qcow2 --file /tmp/centos7.qcow2 centos7
-net_id=$(openstack network list -f value |awk '{print $1}')
-openstack server create --flavor m1.small --image centos7 --nic net-id=${net_id} --key-name centos-cloud-key test-server
+net_id=$(openstack network list -f value |grep public |awk '{print $1}')
+openstack server create --flavor medium --image 'CentOS 7' --nic net-id=${net_id} --key-name centos-cloud-key test-server1
+openstack server create --flavor small --image 'CentOS 6' --nic net-id=${net_id} --key-name centos-cloud-key test-server2
+openstack server create --flavor tiny --image 'Fedora 24' --nic net-id=${net_id} --key-name centos-cloud-key test-server3
 popd

--- a/puppet/Puppetfile
+++ b/puppet/Puppetfile
@@ -1,48 +1,48 @@
 # OpenStack modules
 mod 'cinder',
   :git => 'https://git.openstack.org/openstack/puppet-cinder',
-  :ref => 'stable/mitaka'
+  :ref => 'stable/newton'
 
 mod 'glance',
   :git => 'https://git.openstack.org/openstack/puppet-glance',
-  :ref => 'stable/mitaka'
+  :ref => 'stable/newton'
 
 mod 'horizon',
   :git => 'https://git.openstack.org/openstack/puppet-horizon',
-  :ref => 'stable/mitaka'
+  :ref => 'stable/newton'
 
 mod 'keystone',
   :git => 'https://git.openstack.org/openstack/puppet-keystone',
-  :ref => 'stable/mitaka'
+  :ref => 'stable/newton'
 
 mod 'neutron',
   :git => 'https://git.openstack.org/openstack/puppet-neutron',
-  :ref => 'stable/mitaka'
+  :ref => 'stable/newton'
 
 mod 'nova',
   :git => 'https://git.openstack.org/openstack/puppet-nova',
-  :ref => 'stable/mitaka'
+  :ref => 'stable/newton'
 
 mod 'openstacklib',
   :git => 'https://git.openstack.org/openstack/puppet-openstacklib',
-  :ref => 'stable/mitaka'
+  :ref => 'stable/newton'
 
 mod 'openstack_extras',
   :git => 'https://git.openstack.org/openstack/puppet-openstack_extras',
-  :ref => 'stable/mitaka'
+  :ref => 'stable/newton'
 
 # External modules
 mod 'apache',
   :git => 'https://github.com/puppetlabs/puppetlabs-apache',
-  :branch => '1.8.x'
+  :branch => '1.10.0'
 
 mod 'concat',
   :git => 'https://github.com/puppetlabs/puppetlabs-concat',
-  :branch => '1.2.x'
+  :branch => '2.2.0'
 
 mod 'inifile',
   :git => 'https://github.com/puppetlabs/puppetlabs-inifile',
-  :branch => '1.4.x'
+  :branch => '1.6.0'
 
 mod 'memcached',
   :git => 'https://github.com/saz/puppet-memcached',
@@ -50,7 +50,7 @@ mod 'memcached',
 
 mod 'mysql',
   :git => 'https://github.com/puppetlabs/puppetlabs-mysql',
-  :branch => '3.6.x'
+  :branch => '3.9.0'
 
 mod "ntp",
   :git => "https://github.com/puppetlabs/puppetlabs-ntp.git",
@@ -58,7 +58,7 @@ mod "ntp",
 
 mod 'rabbitmq',
   :git => 'https://github.com/puppetlabs/puppetlabs-rabbitmq',
-  :tag => '5.3.1'
+  :tag => '5.5.0'
 
 mod 'staging',
   :git => 'https://github.com/nanliu/puppet-staging',
@@ -66,7 +66,7 @@ mod 'staging',
 
 mod 'stdlib',
   :git => 'https://github.com/puppetlabs/puppetlabs-stdlib',
-  :branch => '4.9.x'
+  :branch => '4.12.0'
 
 mod 'sysctl',
   :git => 'https://github.com/duritong/puppet-sysctl',

--- a/puppet/Puppetfile
+++ b/puppet/Puppetfile
@@ -1,3 +1,7 @@
+# Overlay module
+mod 'centos_cloud',
+  :local => true
+
 # OpenStack modules
 mod 'glance',
   :git => 'https://git.openstack.org/openstack/puppet-glance',

--- a/puppet/Puppetfile
+++ b/puppet/Puppetfile
@@ -7,10 +7,6 @@ mod 'glance',
   :git => 'https://git.openstack.org/openstack/puppet-glance',
   :ref => 'stable/newton'
 
-mod 'horizon',
-  :git => 'https://git.openstack.org/openstack/puppet-horizon',
-  :ref => 'stable/newton'
-
 mod 'keystone',
   :git => 'https://git.openstack.org/openstack/puppet-keystone',
   :ref => 'stable/newton'

--- a/puppet/Puppetfile
+++ b/puppet/Puppetfile
@@ -1,8 +1,4 @@
 # OpenStack modules
-mod 'cinder',
-  :git => 'https://git.openstack.org/openstack/puppet-cinder',
-  :ref => 'stable/newton'
-
 mod 'glance',
   :git => 'https://git.openstack.org/openstack/puppet-glance',
   :ref => 'stable/newton'

--- a/puppet/Puppetfile
+++ b/puppet/Puppetfile
@@ -27,6 +27,10 @@ mod 'openstack_extras',
   :git => 'https://git.openstack.org/openstack/puppet-openstack_extras',
   :ref => 'stable/newton'
 
+mod 'oslo',
+  :git => 'https://git.openstack.org/openstack/puppet-oslo',
+  :ref => 'stable/newton'
+
 # External modules
 mod 'apache',
   :git => 'https://github.com/puppetlabs/puppetlabs-apache',

--- a/puppet/modules/centos_cloud/manifests/compute/neutron.pp
+++ b/puppet/modules/centos_cloud/manifests/compute/neutron.pp
@@ -1,10 +1,10 @@
 class centos_cloud::compute::neutron (
-  $controller        = 'controller.openstack.ci.centos.org',
-  $memcache_servers  = ['127.0.0.1:11211'],
-  $bind_host         = '0.0.0.0',
-  $rabbit_port       = '5672',
-  $user              = 'neutron',
-  $password          = 'neutron',
+  $controller       = 'controller.openstack.ci.centos.org',
+  $memcache_servers = ['127.0.0.1:11211'],
+  $bind_host        = '0.0.0.0',
+  $rabbit_port      = '5672',
+  $user             = 'neutron',
+  $password         = 'neutron',
 ) {
     class { '::neutron':
     allow_overlapping_ips   => false,
@@ -19,10 +19,10 @@ class centos_cloud::compute::neutron (
   }
 
   class { '::neutron::plugins::ml2':
-    type_drivers          => ['flat'],
-    tenant_network_types  => [],
-    mechanism_drivers     => ['linuxbridge'],
-    flat_networks         => ['physnet0'],
+    type_drivers         => ['flat'],
+    tenant_network_types => [],
+    mechanism_drivers    => ['linuxbridge'],
+    flat_networks        => ['physnet0'],
   }
 
   class { '::neutron::agents::ml2::linuxbridge':

--- a/puppet/modules/centos_cloud/manifests/compute/nova.pp
+++ b/puppet/modules/centos_cloud/manifests/compute/nova.pp
@@ -47,10 +47,10 @@ class centos_cloud::compute::nova (
   }
 
   class { '::nova::network::neutron':
-    firewall_driver    => 'nova.virt.firewall.NoopFirewallDriver',
-    neutron_auth_url   => "http://${controller}:35357/v3",
-    neutron_url        => "http://${controller}:9696",
-    neutron_password   => $neutron_password,
+    firewall_driver  => 'nova.virt.firewall.NoopFirewallDriver',
+    neutron_auth_url => "http://${controller}:35357/v3",
+    neutron_url      => "http://${controller}:9696",
+    neutron_password => $neutron_password,
   }
 
   include ::nova::vncproxy

--- a/puppet/modules/centos_cloud/manifests/compute/nova.pp
+++ b/puppet/modules/centos_cloud/manifests/compute/nova.pp
@@ -1,6 +1,5 @@
 class centos_cloud::compute::nova (
   $controller            = 'controller.openstack.ci.centos.org',
-  $memcached_servers     = ['127.0.0.1:11211'],
   $rabbit_port           = '5672',
   $user                  = 'nova',
   $user_api              = 'nova_api',
@@ -15,7 +14,6 @@ class centos_cloud::compute::nova (
   class { '::nova':
     api_database_connection => "mysql+pymysql://${user_api}:${password_api}@${controller}/nova_api?charset=utf8",
     database_connection     => "mysql+pymysql://${user}:${password}@${controller}/nova?charset=utf8",
-    memcached_servers       => $memcached_servers,
     glance_api_servers      => "http://${controller}:9292",
     notification_driver     => 'messagingv2',
     notify_on_state_change  => 'vm_and_task_state',

--- a/puppet/modules/centos_cloud/manifests/controller.pp
+++ b/puppet/modules/centos_cloud/manifests/controller.pp
@@ -7,4 +7,5 @@ class centos_cloud::controller {
   include centos_cloud::controller::neutron
   include centos_cloud::controller::nova
   include centos_cloud::controller::provision
+  include centos_cloud::controller::quotas
 }

--- a/puppet/modules/centos_cloud/manifests/controller.pp
+++ b/puppet/modules/centos_cloud/manifests/controller.pp
@@ -6,4 +6,5 @@ class centos_cloud::controller {
   include centos_cloud::controller::glance
   include centos_cloud::controller::neutron
   include centos_cloud::controller::nova
+  include centos_cloud::controller::provision
 }

--- a/puppet/modules/centos_cloud/manifests/controller/glance.pp
+++ b/puppet/modules/centos_cloud/manifests/controller/glance.pp
@@ -43,26 +43,36 @@ class centos_cloud::controller::glance (
     password     => $password
   }
 
-  class { '::glance::api':
+  class { '::glance::api::authtoken':
+    password            => $password,
+    user_domain_name    => 'Default',
+    project_domain_name => 'Default',
+    auth_url            => "http://${controller}:35357",
     auth_uri            => "http://${controller}:5000",
+    memcached_servers   => $memcached_servers,
+  }
+
+  class { '::glance::api':
     bind_host           => $bind_host,
     database_connection => "mysql+pymysql://${user}:${password}@${controller}/glance?charset=utf8",
-    memcached_servers   => $memcached_servers,
     default_store       => $backend,
-    identity_uri        => "http://${controller}:35357",
-    keystone_password   => $password,
     registry_host       => $controller,
     stores              => $stores,
     workers             => $workers
   }
 
-  class { '::glance::registry':
+  class { '::glance::registry::authtoken':
+    password            => $password,
+    user_domain_name    => 'Default',
+    project_domain_name => 'Default',
+    auth_url            => "http://${controller}:35357",
     auth_uri            => "http://${controller}:5000",
+    memcached_servers   => $memcached_servers,
+  }
+
+  class { '::glance::registry':
     bind_host           => $bind_host,
     database_connection => "mysql+pymysql://${user}:${password}@${controller}/glance?charset=utf8",
-    memcached_servers   => $memcached_servers,
-    identity_uri        => "http://${controller}:35357",
-    keystone_password   => $password,
     workers             => $workers
   }
 

--- a/puppet/modules/centos_cloud/manifests/controller/glance.pp
+++ b/puppet/modules/centos_cloud/manifests/controller/glance.pp
@@ -1,5 +1,5 @@
 class centos_cloud::controller::glance (
-  $allowed_hosts     = "172.22.6.0/23",
+  $allowed_hosts     = '172.22.6.0/23',
   $backend           = 'file',
   $bind_host         = '0.0.0.0',
   $controller        = 'controller.openstack.ci.centos.org',

--- a/puppet/modules/centos_cloud/manifests/controller/keystone.pp
+++ b/puppet/modules/centos_cloud/manifests/controller/keystone.pp
@@ -1,15 +1,15 @@
 class centos_cloud::controller::keystone (
-  $allowed_hosts          = "172.22.6.0/23",
-  $bind_host              = '0.0.0.0',
-  $controller             = 'controller.openstack.ci.centos.org',
-  $password               = 'keystone',
-  $user                   = 'keystone',
-  $token_provider         = 'fernet',
-  $enable_fernet_setup    = true,
-  $admin_workers          = '16',
-  $public_workers         = '16',
-  $workers                = '16',
-  $threads                = '1'
+  $allowed_hosts       = '172.22.6.0/23',
+  $bind_host           = '0.0.0.0',
+  $controller          = 'controller.openstack.ci.centos.org',
+  $password            = 'keystone',
+  $user                = 'keystone',
+  $token_provider      = 'fernet',
+  $enable_fernet_setup = true,
+  $admin_workers       = '16',
+  $public_workers      = '16',
+  $workers             = '16',
+  $threads             = '1'
 ) {
 
   include ::keystone::client
@@ -21,16 +21,16 @@ class centos_cloud::controller::keystone (
   }
 
   class { '::keystone':
-    admin_bind_host        => $bind_host,
-    admin_token            => $password,
-    database_connection    => "mysql+pymysql://${user}:${password}@${controller}/keystone",
-    enabled                => true,
-    public_bind_host       => $bind_host,
-    service_name           => 'httpd',
-    token_provider         => $token_provider,
-    enable_fernet_setup    => $enable_fernet_setup,
-    admin_workers          => $admin_workers,
-    public_workers         => $public_workers
+    admin_bind_host     => $bind_host,
+    admin_token         => $password,
+    database_connection => "mysql+pymysql://${user}:${password}@${controller}/keystone",
+    enabled             => true,
+    public_bind_host    => $bind_host,
+    service_name        => 'httpd',
+    token_provider      => $token_provider,
+    enable_fernet_setup => $enable_fernet_setup,
+    admin_workers       => $admin_workers,
+    public_workers      => $public_workers
   }
 
   include ::apache

--- a/puppet/modules/centos_cloud/manifests/controller/keystone.pp
+++ b/puppet/modules/centos_cloud/manifests/controller/keystone.pp
@@ -33,25 +33,6 @@ class centos_cloud::controller::keystone (
     public_workers         => $public_workers
   }
 
-  # Remove me when this is merged, built and released:
-  # https://review.rdoproject.org/r/#/c/1144/
-  file { '/var/log/keystone':
-    ensure  => directory,
-    owner   => 'keystone',
-    group   => 'keystone',
-    mode    => '0750',
-    before  => Exec['keystone-manage db_sync'],
-    require => Package['keystone']
-  }->
-  file { '/var/log/keystone/keystone.log':
-    ensure  => file,
-    owner   => 'root',
-    group   => 'keystone',
-    mode    => '0660',
-    before  => Exec['keystone-manage db_sync'],
-    require => Package['keystone']
-  }
-
   include ::apache
   class { '::keystone::wsgi::apache':
     admin_bind_host => $bind_host,

--- a/puppet/modules/centos_cloud/manifests/controller/mysql.pp
+++ b/puppet/modules/centos_cloud/manifests/controller/mysql.pp
@@ -10,7 +10,7 @@ class centos_cloud::controller::mysql {
   }
 
   exec { 'Reload systemctl':
-    command     => "/usr/bin/systemctl daemon-reload",
+    command     => '/usr/bin/systemctl daemon-reload',
     refreshonly => true
   }
 

--- a/puppet/modules/centos_cloud/manifests/controller/neutron.pp
+++ b/puppet/modules/centos_cloud/manifests/controller/neutron.pp
@@ -1,14 +1,14 @@
 class centos_cloud::controller::neutron (
-  $allowed_hosts     = "172.22.6.0/23",
-  $controller        = 'controller.openstack.ci.centos.org',
-  $memcache_servers  = ['127.0.0.1:11211'],
-  $bind_host         = '0.0.0.0',
-  $rabbit_port       = '5672',
-  $user              = 'neutron',
-  $password          = 'neutron',
-  $nova_password     = 'nova',
-  $api_workers       = '8',
-  $rpc_workers       = '8'
+  $allowed_hosts    = '172.22.6.0/23',
+  $controller       = 'controller.openstack.ci.centos.org',
+  $memcache_servers = ['127.0.0.1:11211'],
+  $bind_host        = '0.0.0.0',
+  $rabbit_port      = '5672',
+  $user             = 'neutron',
+  $password         = 'neutron',
+  $nova_password    = 'nova',
+  $api_workers      = '8',
+  $rpc_workers      = '8'
 ) {
 
   rabbitmq_user { $user:
@@ -70,10 +70,10 @@ class centos_cloud::controller::neutron (
   }
 
   class { '::neutron::plugins::ml2':
-    type_drivers          => ['flat'],
-    tenant_network_types  => [],
-    mechanism_drivers     => ['linuxbridge'],
-    flat_networks         => ['physnet0'],
+    type_drivers         => ['flat'],
+    tenant_network_types => [],
+    mechanism_drivers    => ['linuxbridge'],
+    flat_networks        => ['physnet0'],
   }
 
   class { '::neutron::agents::ml2::linuxbridge':

--- a/puppet/modules/centos_cloud/manifests/controller/neutron.pp
+++ b/puppet/modules/centos_cloud/manifests/controller/neutron.pp
@@ -81,20 +81,4 @@ class centos_cloud::controller::neutron (
     local_ip                    => $::ipaddress,
     physical_interface_mappings => ['physnet0:eth0'],
   }
-
-  # Provider network
-  neutron_network { 'publicnet':
-    shared                    => true,
-    provider_network_type     => 'flat',
-    provider_physical_network => 'physnet0',
-  }
-
-  # Provider subnet
-  neutron_subnet { 'publicsubnet':
-    cidr             => '172.19.4.0/22',
-    gateway_ip       => '172.19.7.254',
-    network_name     => 'publicnet',
-    dns_nameservers  => ['172.19.7.253'],
-    allocation_pools => ["start=172.19.4.10,end=172.19.7.250"],
-  }
 }

--- a/puppet/modules/centos_cloud/manifests/controller/nova.pp
+++ b/puppet/modules/centos_cloud/manifests/controller/nova.pp
@@ -98,5 +98,4 @@ class centos_cloud::controller::nova (
   include ::nova::cron::archive_deleted_rows
   include ::nova::scheduler
   include ::nova::scheduler::filter
-
 }

--- a/puppet/modules/centos_cloud/manifests/controller/nova.pp
+++ b/puppet/modules/centos_cloud/manifests/controller/nova.pp
@@ -41,7 +41,6 @@ class centos_cloud::controller::nova (
   }
 
   class { '::nova::keystone::auth':
-    configure_ec2_endpoint => false,
     configure_endpoint_v3  => false,
     admin_url              => "http://${controller}:8774/v2/%(tenant_id)s",
     internal_url           => "http://${controller}:8774/v2/%(tenant_id)s",

--- a/puppet/modules/centos_cloud/manifests/controller/nova.pp
+++ b/puppet/modules/centos_cloud/manifests/controller/nova.pp
@@ -41,17 +41,24 @@ class centos_cloud::controller::nova (
   }
 
   class { '::nova::keystone::auth':
-    configure_endpoint_v3  => false,
-    admin_url              => "http://${controller}:8774/v2/%(tenant_id)s",
-    internal_url           => "http://${controller}:8774/v2/%(tenant_id)s",
-    public_url             => "http://${controller}:8774/v2/%(tenant_id)s",
-    password               => $password
+    admin_url    => "http://${controller}:8774/v2/%(tenant_id)s",
+    internal_url => "http://${controller}:8774/v2/%(tenant_id)s",
+    public_url   => "http://${controller}:8774/v2/%(tenant_id)s",
+    password     => $password
+  }
+
+  class { '::nova::keystone::authtoken':
+    password            => $password,
+    user_domain_name    => 'Default',
+    project_domain_name => 'Default',
+    auth_url            => "http://${controller}:35357",
+    auth_uri            => "http://${controller}:5000",
+    memcached_servers   => $memcached_servers,
   }
 
   class { '::nova':
     api_database_connection => "mysql+pymysql://${user_api}:${password_api}@${controller}/nova_api?charset=utf8",
     database_connection     => "mysql+pymysql://${user}:${password}@${controller}/nova?charset=utf8",
-    memcached_servers       => $memcached_servers,
     glance_api_servers      => "http://${controller}:9292",
     notification_driver     => 'messagingv2',
     notify_on_state_change  => 'vm_and_task_state',
@@ -63,12 +70,8 @@ class centos_cloud::controller::nova (
   }
 
   class { '::nova::api':
-    admin_password        => $password,
     api_bind_address      => $bind_host,
-    auth_uri              => "http://${controller}:5000",
     enabled_apis          => ['osapi_compute'],
-    identity_uri          => "http://${controller}:35357",
-    osapi_v3              => true,
     service_name          => 'httpd',
     sync_db_api           => true,
     osapi_compute_workers => $workers,

--- a/puppet/modules/centos_cloud/manifests/controller/nova.pp
+++ b/puppet/modules/centos_cloud/manifests/controller/nova.pp
@@ -85,10 +85,10 @@ class centos_cloud::controller::nova (
   }
 
   class { '::nova::network::neutron':
-    firewall_driver    => 'nova.virt.firewall.NoopFirewallDriver',
-    neutron_auth_url   => "http://${controller}:35357/v3",
-    neutron_url        => "http://${controller}:9696",
-    neutron_password   => $neutron_password,
+    firewall_driver  => 'nova.virt.firewall.NoopFirewallDriver',
+    neutron_auth_url => "http://${controller}:35357/v3",
+    neutron_url      => "http://${controller}:9696",
+    neutron_password => $neutron_password,
   }
 
   include ::nova::client

--- a/puppet/modules/centos_cloud/manifests/controller/nova.pp
+++ b/puppet/modules/centos_cloud/manifests/controller/nova.pp
@@ -71,7 +71,8 @@ class centos_cloud::controller::nova (
     osapi_v3              => true,
     service_name          => 'httpd',
     sync_db_api           => true,
-    osapi_compute_workers => $workers
+    osapi_compute_workers => $workers,
+    install_cinder_client => false
   }
 
   include ::apache

--- a/puppet/modules/centos_cloud/manifests/controller/provision.pp
+++ b/puppet/modules/centos_cloud/manifests/controller/provision.pp
@@ -42,7 +42,7 @@ class centos_cloud::controller::provision {
     gateway_ip       => '172.19.3.254',
     network_name     => 'publicnet',
     dns_nameservers  => ['172.19.0.12'],
-    allocation_pools => ["start=172.19.4.10,end=172.19.7.250"],
+    allocation_pools => ['start=172.19.4.10,end=172.19.7.250'],
   }
 
   ###

--- a/puppet/modules/centos_cloud/manifests/controller/provision.pp
+++ b/puppet/modules/centos_cloud/manifests/controller/provision.pp
@@ -38,10 +38,10 @@ class centos_cloud::controller::provision {
   }
 
   neutron_subnet { 'publicsubnet':
-    cidr             => '172.19.4.0/22',
-    gateway_ip       => '172.19.7.254',
+    cidr             => '172.19.4.0/21',
+    gateway_ip       => '172.19.3.254',
     network_name     => 'publicnet',
-    dns_nameservers  => ['172.19.7.253'],
+    dns_nameservers  => ['172.19.0.12'],
     allocation_pools => ["start=172.19.4.10,end=172.19.7.250"],
   }
 

--- a/puppet/modules/centos_cloud/manifests/controller/provision.pp
+++ b/puppet/modules/centos_cloud/manifests/controller/provision.pp
@@ -1,0 +1,76 @@
+class centos_cloud::controller::provision {
+  ###
+  # Nova
+  ###
+  Keystone_user_role['admin@openstack'] -> Nova_flavor<||>
+
+  nova_flavor { 'tiny':
+    ensure => present,
+    ram    => '2048',
+    disk   => '20',
+    vcpus  => '1',
+  }
+
+  nova_flavor { 'small':
+    ensure => present,
+    ram    => '4096',
+    disk   => '40',
+    vcpus  => '2',
+  }
+
+  nova_flavor { 'medium':
+    ensure => present,
+    ram    => '8192',
+    disk   => '80',
+    vcpus  => '4',
+  }
+
+  ###
+  # Neutron
+  ###
+  Keystone_user_role['admin@openstack'] -> Neutron_network<||>
+  Keystone_user_role['admin@openstack'] -> Neutron_subnet<||>
+
+  neutron_network { 'publicnet':
+    shared                    => true,
+    provider_network_type     => 'flat',
+    provider_physical_network => 'physnet0',
+  }
+
+  neutron_subnet { 'publicsubnet':
+    cidr             => '172.19.4.0/22',
+    gateway_ip       => '172.19.7.254',
+    network_name     => 'publicnet',
+    dns_nameservers  => ['172.19.7.253'],
+    allocation_pools => ["start=172.19.4.10,end=172.19.7.250"],
+  }
+
+  ###
+  # Glance
+  ###
+  Keystone_user_role['admin@openstack'] -> Glance_image<||>
+
+  glance_image { 'CentOS 7':
+    ensure           => present,
+    container_format => 'bare',
+    disk_format      => 'qcow2',
+    is_public        => 'yes',
+    source           => 'http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2'
+  }
+
+  glance_image { 'CentOS 6':
+    ensure           => present,
+    container_format => 'bare',
+    disk_format      => 'qcow2',
+    is_public        => 'yes',
+    source           => 'http://cloud.centos.org/centos/6/images/CentOS-6-x86_64-GenericCloud.qcow2'
+  }
+
+  glance_image { 'Fedora 24':
+    ensure           => present,
+    container_format => 'bare',
+    disk_format      => 'qcow2',
+    is_public        => 'yes',
+    source           => 'https://download.fedoraproject.org/pub/fedora/linux/releases/24/CloudImages/x86_64/images/Fedora-Cloud-Base-24-1.2.x86_64.qcow2'
+  }
+}

--- a/puppet/modules/centos_cloud/manifests/controller/quotas.pp
+++ b/puppet/modules/centos_cloud/manifests/controller/quotas.pp
@@ -1,0 +1,115 @@
+# == Class: centos_cloud::controller::quotas
+#
+# Configures the default project quotas.
+# These default project quotas are based the flavors that are provisioned.
+# We have the tiny, small and medium flavors.
+# The quotas are based around being able to provide:
+#   - 5 medium instances, or
+#   - 10 small instances, or
+#   - 20 tiny instances
+#
+# These defaults can be overridden per-project by an administrator.
+#
+# === Parameters:
+#
+# ## Nova
+#
+# [*instances*]
+#   (optional) Max amount of instances per project.
+#   Defaults to 20.
+#
+# [*cores*]
+#   (optional) Max amount of vCPUs per project.
+#   Defaults to 20.
+#
+# [*ram*]
+#   (optional) Max amount of RAM per project.
+#   Defaults to 40960MB.
+#
+# [*fixed_ips*]
+#   (optional) Max amount of fixed IPs per project.
+#   Defaults to 20 (number of instances)
+#
+# [*security_groups*]
+#   (optional) Max amount of security groups per project.
+#   Defaults to 0 (security groups are not enabled on this deployment)
+#
+# [*security_group_rules*]
+#   (optional) Max amount of security group rules per project.
+#   Defaults to 0 (security groups are not enabled on this deployment)
+#
+# ## Neutron
+#
+# [*ports*]
+#   (optional) Max amount of ports per project.
+#   Defaults to 20 (number of instances)
+#
+# [*network*]
+#   (optional) Max amount of networks per project.
+#   Defaults to 0 (projects are not allowed to create their own networks)
+#
+# [*subnet*]
+#   (optional) Max amount of subnets per project.
+#   Defaults to 0 (projects are not allowed to create their own subnets)
+#
+# [*network_gateway*]
+#   (optional) Max amount of network gateways per project.
+#   There are no L3 agents on this deployment, it uses flat provider networks.
+#   Defaults to 0
+#
+# [*router*]
+#   (optional) Max amount of routers per project.
+#   There are no L3 agents on this deployment, it uses flat provider networks.
+#   Defaults to 0
+#
+# [*floating_ip*]
+#   (optional) Max amount of floating IPs per project.
+#   There are no L3 agents on this deployment, it uses flat provider networks.
+#   Defaults to 0
+#
+# ## Glance
+#
+# [*image_storage*]
+#   (optional) Max size of image storage (images and snapshots) per project.
+#   Defaults to '5GB'
+
+class centos_cloud::controller::quotas (
+  # Nova
+  $instances            = 20,
+  $cores                = 20,
+  $ram                  = 40960,
+  $fixed_ips            = 20,
+  $security_groups      = 0,
+  $security_group_rules = 0,
+  # Neutron
+  $ports                = 20,
+  $network              = 0,
+  $subnet               = 0,
+  $network_gateway      = 0,
+  $router               = 0,
+  $floatingip           = 0,
+  # Glance
+  $image_storage        = '5GB'
+){
+  class { '::nova::quota':
+    quota_instances            => $instances,
+    quota_cores                => $cores,
+    quota_ram                  => $ram,
+    quota_fixed_ips            => $fixed_ips,
+    quota_security_groups      => $security_groups,
+    quota_security_group_rules => $security_group_rules,
+  }
+
+  class { '::neutron::quota':
+    quota_ports           => $ports,
+    quota_network         => $network,
+    quota_subnet          => $subnet,
+    quota_network_gateway => $network_gateway,
+    quota_router          => $router,
+    quota_floatingip      => $floatingip
+  }
+
+  glance_api_config { 'DEFAULT/user_storage_quota':
+    value => $image_storage;
+  }
+}

--- a/puppet/modules/centos_cloud/manifests/server/auth_file.pp
+++ b/puppet/modules/centos_cloud/manifests/server/auth_file.pp
@@ -1,7 +1,7 @@
 class centos_cloud::server::auth_file (
-  $controller = "controller.openstack.ci.centos.org",
-  $password = "keystone",
-  $path = '/root/openrc'
+  $controller = 'controller.openstack.ci.centos.org',
+  $password   = 'keystone',
+  $path       = '/root/openrc'
 ){
   class { '::openstack_extras::auth_file':
     auth_url       => "http://${controller}:5000/v3/",


### PR DESCRIPTION
- Bump OpenStack and puppet module release to Newton
- Fix deprecations/removals with new configurations and parameters
- Remove workaround for keystone logs that was required in Mitaka
- Add flavor and base image provisioning
- Some minor improvements to bootstrap scripts
